### PR TITLE
[tools-build] Change the build order to first build fesvr

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -81,19 +81,6 @@ fi
 #make &>> $OUTPUT_FILE
 #make install &>> $OUTPUT_FILE
 
-# Build riscv-tests
-OUTPUT_FILE=$OUTPUT_PATH/riscv-tests.log
-echo "Building riscv-tests... (writing output to $OUTPUT_FILE)"
-cd $RISCV
-mkdir build-tests
-cd build-tests
-../../riscv-tests/configure --prefix=$RISCV/riscv$XLEN-unknown-elf &> $OUTPUT_FILE
-# This may fail since some riscv-tests require ISA extensions
-# Also there is an issue with building 32-bit executables when gcc is
-# configured with --with-arch=<isa>
-make &>> $OUTPUT_FILE
-make install &>> $OUTPUT_FILE
-
 # Build riscv-fesvr
 OUTPUT_FILE=$OUTPUT_PATH/riscv-fesvr.log
 echo "Building riscv-fesvr... (writing output to $OUTPUT_FILE)"
@@ -101,6 +88,19 @@ cd $RISCV
 mkdir -p build-fesvr
 cd build-fesvr
 ../../riscv-fesvr/configure --prefix=$RISCV &> $OUTPUT_FILE
+make &>> $OUTPUT_FILE
+make install &>> $OUTPUT_FILE
+
+# Build riscv-tests
+OUTPUT_FILE=$OUTPUT_PATH/riscv-tests.log
+echo "Building riscv-tests... (writing output to $OUTPUT_FILE)"
+cd $RISCV
+mkdir -p build-tests
+cd build-tests
+../../riscv-tests/configure --prefix=$RISCV/riscv$XLEN-unknown-elf &> $OUTPUT_FILE
+# This may fail since some riscv-tests require ISA extensions
+# Also there is an issue with building 32-bit executables when gcc is
+# configured with --with-arch=<isa>
 make &>> $OUTPUT_FILE
 make install &>> $OUTPUT_FILE
 


### PR DESCRIPTION
Change the build order to first build riscv-fesvr before the riscv-tests. This is needed because riscv-tests requires elf2hex, which is built in riscv-fesvr.

Additionally, add the -p option to mkdir to allow multiple runs without failing when building riscv-tests.