### PR TITLE
Fix incorrect counter returned by RenameStage

### DIFF
--- a/procs/RV64G_OOO/RenameStage.bsv
+++ b/procs/RV64G_OOO/RenameStage.bsv
@@ -954,7 +954,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
             SupRenameCnt: supRenameCnt;
 `ifdef SECURITY
             SpecNoneCycles: specNoneCycles;
-            SpecNonMemCycles: specNoneCycles;
+            SpecNonMemCycles: specNonMemCycles;
 `endif
 `endif
             default: 0;


### PR DESCRIPTION
When requesting the SpecNonMemCycles counter, the wrong one is returned. The correct counter exists and counts, so simply return that one instead.